### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "pip"
       - "dependencies"
-    allow:
-      - dependency-name: "slack-bolt"


### PR DESCRIPTION
This pull request adds the configuration for Dependabot, limiting updates to the `slack-bolt` package.