### PR TITLE
Adding Heroku `deploy` button to Bolt Python starter template

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: python app.py

--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@ This is a generic Bolt for Python template app used to build out Slack apps.
 Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
 ## Installation
 
-# Deploy to Heroku
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/allhaile/bolt-python-starter-template)
-
-
-
 #### Create a Slack App
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
 2. Choose the workspace you want to install the application to
@@ -28,6 +23,16 @@ Before you can run the app, you'll need to store some environment variables.
 export SLACK_BOT_TOKEN=<your-bot-token>
 export SLACK_APP_TOKEN=<your-app-token>
 ```
+
+## Heroku Deployment
+Use the `Deploy to Heroku` button below to launch this app on Heroku. Ensure your Heroku config vars include the required Slack env variables.
+<!--
+  NOTE: This Deploy to Heroku button currently points to my personal fork
+  to allow testing of the latest changes.
+  Before merging this PR, be sure to update the URL to point to the
+  official Slack bolt-python-starter-template repository (https://github.com/slack-samples/bolt-python-starter-template).
+-->
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/allhaile/bolt-python-starter-template)
 
 ### Setup Your Local Project
 ```zsh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Before getting started, make sure you have a development workspace where you hav
 ## Installation
 
 # Deploy to Heroku
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/allhaile/bolt-python-starter-template)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/allhaile/bolt-python-starter-template)
+
 
 
 #### Create a Slack App

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This is a generic Bolt for Python template app used to build out Slack apps.
 Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
 ## Installation
 
+# Deploy to Heroku
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/allhaile/bolt-python-starter-template)
+
+
 #### Create a Slack App
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
 2. Choose the workspace you want to install the application to

--- a/app.json
+++ b/app.json
@@ -1,0 +1,23 @@
+{
+  "name": "Bolt for Python Starter App (Socket Mode)",
+  "description": "A Slack app using Bolt for Python with Socket Mode",
+  "env": {
+    "SLACK_BOT_TOKEN": {
+      "description": "Your bot token (starts with xoxb-)",
+      "required": true
+    },
+    "SLACK_APP_TOKEN": {
+      "description": "Your app-level token (starts with xapp-)",
+      "required": true
+    }
+  },
+  "scripts": {
+    "postdeploy": "echo 'Your Bolt for Python Socket Mode app was deployed!'"
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/python"
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] New sample
- [X] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR is part of [#proj-slack-sample-apps-heroku-deploy-buttons](https://salesforce.enterprise.slack.com/archives/C091DC59NG1), an initiative to add Heroku one-click deployment buttons across all Slack sample app templates, making it easier for developers to quickly deploy and test Slack apps. 

### Files added:
- **`app.json`** - New Heroku app manifest defining deployment configuration
- **`Procfile`** - Process definition for Heroku (worker dyno for socket mode)

### Technical details:
- Configured for socket mode deployment using worker dyno (not web dyno)
- Includes all required environment variables for Slack app setup
- Repository URL currently points to personal fork (will update before merge)

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
